### PR TITLE
Changed AllWithThrottle so a new fn can start as soon as a previous one completes

### DIFF
--- a/coop_test.go
+++ b/coop_test.go
@@ -15,6 +15,7 @@
 package coop
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -105,41 +106,97 @@ func TestTimeout_Completed(test *testing.T) {
 }
 
 func TestAll(test *testing.T) {
-	start := time.Now()
-	var val1, val2, val3 bool
+	var ndone int32 = 0
 	done := All(func() {
-		val1 = true
-		time.Sleep(100 * time.Millisecond)
+		atomic.AddInt32(&ndone, 1)
 	}, func() {
-		val2 = true
-		time.Sleep(100 * time.Millisecond)
+		atomic.AddInt32(&ndone, 1)
 	}, func() {
-		val3 = true
-		time.Sleep(100 * time.Millisecond)
+		atomic.AddInt32(&ndone, 1)
 	})
 	<-done
-	diff := time.Now().Sub(start)
-	if diff > 105*time.Millisecond {
-		test.Errorf("All takes too long to complete")
-	}
-	if !(val1 && val2 && val3) {
-		test.Errorf("Expected all to run, but at least one didn't")
+	if atomic.LoadInt32(&ndone) != 3 {
+		test.Errorf("Only %d fn completed, expected 3", ndone)
 	}
 }
 
 func TestAllWithThrottle(test *testing.T) {
-	start := time.Now()
+	var nlive int32 = 0
+	var ndone int32 = 0
+	sch := make(chan struct{}, 5)
+	cch := make(chan struct{})
+	fch := make(chan struct{})
 	fn := func() {
-		time.Sleep(100 * time.Millisecond)
+		atomic.AddInt32(&nlive, 1)
+		sch <- struct{}{} // Notify that nlive has been updated
+		<-cch             // Wait for permission to continue
+		atomic.AddInt32(&ndone, 1)
+		fch <- struct{}{}
 	}
-	done := AllWithThrottle(3, fn, fn, fn, fn, fn)
+	done := AllWithThrottle(2, fn, fn, fn, fn, fn)
+	<-sch
+	<-sch
+	// If less than 2 fn are started, the test will hang.
+
+	l1 := atomic.LoadInt32(&nlive)
+	if l1 != 2 {
+		test.Errorf("Expected 2 live fn, got %d", l1)
+	}
+
+	// Let 2 fn continue
+	cch <- struct{}{}
+	cch <- struct{}{}
+
+	// Wait for 2 fn to finish and update ndone
+	<-fch
+	<-fch
+
+	// Wait for two more fn to start and update nlive
+	<-sch
+	<-sch
+
+	l2 := atomic.LoadInt32(&nlive)
+	if l2 != 4 {
+		test.Errorf("Expected 4 live fn, got %d", l2)
+	}
+
+	d1 := atomic.LoadInt32(&ndone)
+	if d1 != 2 {
+		test.Errorf("Expected 2 done fn, got %d", d1)
+	}
+
+	// Let 2 fn continue
+	cch <- struct{}{}
+	cch <- struct{}{}
+
+	// Wait for 2 fn to finish and update ndone
+	<-fch
+	<-fch
+
+	// Wait for last more fn to start and update nlive
+	<-sch
+
+	l3 := atomic.LoadInt32(&nlive)
+	if l3 != 5 {
+		test.Errorf("Expected 5 live fn, got %d", l3)
+	}
+
+	d2 := atomic.LoadInt32(&ndone)
+	if d2 != 4 {
+		test.Errorf("Expected 4 done fn, got %d", d2)
+	}
+
+	// Let last fn continue
+	cch <- struct{}{}
+
+	// Wait for last fn to finish and update ndone
+	<-fch
+
 	<-done
-	diff := time.Now().Sub(start)
-	if diff > 205*time.Millisecond {
-		test.Errorf("All with throttle takes too long to complete")
-	}
-	if diff < 105*time.Millisecond {
-		test.Errorf("All with throttle doesn't take long, throttling may not work")
+
+	d3 := atomic.LoadInt32(&ndone)
+	if d3 != 5 {
+		test.Errorf("Expected 5 done fn, got %d", d3)
 	}
 }
 


### PR DESCRIPTION
- Modified AllWithThrottle so that new fn are started one at a time as each previously started fn finishes.
- Modified TestAll and TestAllWithThrottle so that they are not timing sensitive.
